### PR TITLE
example: `planingfsi` casehandler

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-max-line-length = 100
+max-line-length = 120
 ignore = E203, W503
 exclude = venv
 per-file-ignores =

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ venv.bak/
 *.swp
 .idea
 .vscode/
+
+# Example case outputs
+/examples/**/cases/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,5 +38,4 @@ repos:
   rev: v0.961
   hooks:
   - id: mypy
-    stages: [push]
     additional_dependencies: [types-toml]

--- a/examples/planingfsi/flat_plate/flat_plate_base/configDict.base
+++ b/examples/planingfsi/flat_plate/flat_plate_base/configDict.base
@@ -1,0 +1,46 @@
+# General Parameters
+rho   : 998.2
+g     : 9.81
+nu    : 1.0048e-6
+hWL   : 0.0
+
+Fr    : 0.5
+AOA   : 10.0
+#U : 5.0
+Lc    : 1.0
+
+wettedLengthSolver : 'broyden'
+wettedLengthMaxStepPct : 0.5
+
+# Simulation Parameters
+maxIt  : 5000
+rampIt : 0
+relaxI : 0.0
+relaxF : 1.0
+tolerance : 1e-5
+
+# Plotting Parameters
+extE   :  0.5
+extW   :  1.0
+extN   :  1.2
+extS   :  1.0
+xFSMin : -15.0
+xFSMax :  10.0
+growthRate : 1.05
+pScaleType : 'stagnation'
+pScalePct  : 0.1
+forceBasePct  : 0.05
+forceScalePct : 0.05
+
+inputDictDir           : './inputDict'
+meshDir                : './mesh'
+meshDictDir            : './meshDict'
+pressureCushionDictDir : './pressureCushion'
+bodyDictDir            : './bodyDict'
+
+shearCalc : False
+writeInterval : 50
+
+plotSave  : False
+plotShow  : False
+plotWatch : False

--- a/examples/planingfsi/flat_plate/flat_plate_base/configDict.base
+++ b/examples/planingfsi/flat_plate/flat_plate_base/configDict.base
@@ -24,9 +24,9 @@ extE   :  0.5
 extW   :  1.0
 extN   :  1.2
 extS   :  1.0
-xFSMin : -15.0
-xFSMax :  10.0
-growthRate : 1.05
+xFSMin : -10.0
+xFSMax :  5.0
+growthRate : 1.02
 pScaleType : 'stagnation'
 pScalePct  : 0.1
 forceBasePct  : 0.05

--- a/examples/planingfsi/flat_plate/flat_plate_base/inputDict/plateDict
+++ b/examples/planingfsi/flat_plate/flat_plate_base/inputDict/plateDict
@@ -1,0 +1,17 @@
+substructureName  : 'plate'
+substructureType  : 'rigid'
+hasPlaningSurface : True
+
+# Fluid Parameters
+Nfl    :  40
+pointSpacing : 'cosine'
+
+kuttaPressure : 0.0
+
+initialLength : 0.48
+minimumLength : 0.01
+structInterpType : 'cubic'
+structExtrap : True
+
+# Simulation Parameters
+sSepPctStart : 0.5

--- a/examples/planingfsi/flat_plate/flat_plate_base/meshDict
+++ b/examples/planingfsi/flat_plate/flat_plate_base/meshDict
@@ -1,0 +1,14 @@
+from planingfsi.dictionary import load_dict_from_file
+
+# Create submeshes
+dict_ = load_dict_from_file('configDict')
+AOA = dict_.get('AOA', 10.0)
+
+# Create points (ID, type, params)
+mesh.add_point(1, 'rel', [ 0, 180, 0.5])
+mesh.add_point(2, 'rel', [ 0,   0, 3.0])
+
+mesh.rotate_points(0, AOA, [1, 2])
+
+mesh_fwd = mesh.add_submesh('plate')
+mesh_fwd.add_curve(1, 2, Nel=10)

--- a/examples/planingfsi/run_planingfsi.py
+++ b/examples/planingfsi/run_planingfsi.py
@@ -155,8 +155,8 @@ class PlaningPlateCase(Case):
 
 
 def main() -> None:
-    froude_nums = numpy.linspace(0.5, 3.0, 7)
-    AOA_nums = numpy.linspace(5.0, 15.0, 5)
+    froude_nums = numpy.arange(0.5, 3.0, 0.25)
+    AOA_nums = numpy.arange(5.0, 15.1, 2.5)
 
     all_results = []
 
@@ -169,7 +169,7 @@ def main() -> None:
         all_results.append(results_dict)
 
     df = pandas.DataFrame.from_records(all_results)
-    df.plot.scatter(x="froude_num", y="lift", c="aoa")
+    df.plot.scatter(x="froude_num", y="lift", c="aoa", cmap="inferno")
 
     pyplot.show()
 

--- a/examples/planingfsi/run_planingfsi.py
+++ b/examples/planingfsi/run_planingfsi.py
@@ -20,7 +20,7 @@ from matplotlib import pyplot
 from planingfsi.dictionary import load_dict_from_file
 
 from lead import Case
-from lead import InputAttribute
+from lead import InputParameter
 from lead import step
 
 FLAT_PLATE_ROOT = Path(__file__).parent / "flat_plate"
@@ -34,8 +34,8 @@ class PlaningPlateResults:
 
 
 class PlaningPlateCase(Case):
-    froude_num = InputAttribute(type=float, min=0.2, max=3.0)
-    angle_of_attack = InputAttribute(type=float)
+    froude_num = InputParameter(type=float, min=0.2, max=3.0)
+    angle_of_attack = InputParameter(type=float)
 
     @property
     def case_dir(self) -> Path:
@@ -66,7 +66,7 @@ class PlaningPlateCase(Case):
         """A dictionary of values for each `InputAttribute`."""
         inputs_dict = {}
         for name, attr in self.__class__.__dict__.items():
-            if isinstance(attr, InputAttribute):
+            if isinstance(attr, InputParameter):
                 inputs_dict[name] = getattr(self, name)
         return inputs_dict
 

--- a/examples/planingfsi/run_planingfsi.py
+++ b/examples/planingfsi/run_planingfsi.py
@@ -31,6 +31,10 @@ class PlaningPlateResults:
 class Case:
     """Base case for all cases."""
 
+    def __init__(self, **kwargs: Any):
+        for name, value in kwargs.items():
+            setattr(self, name, value)
+
 
 def step(condition: Callable[[Any], bool]) -> Any:
     def decorator(f: Callable[[Case], None]) -> Callable[[Case], None]:
@@ -46,10 +50,56 @@ def step(condition: Callable[[Any], bool]) -> Any:
     return decorator
 
 
+class _NoDefault:
+    """Used as a sentinel to indicate lack of a default value for an `InputAttribute`."""
+
+
+_builtin_type = type
+
+
+class InputAttribute:
+    _type: type | None
+    _name: str
+
+    def __init__(self, *, type: type | None = None, default: Any = _NoDefault):
+        if type is not None:
+            self._type = type
+        elif default != _NoDefault:
+            self._type = _builtin_type(default)
+        else:
+            self._type = None
+
+        self._default = default
+
+    def __set_name__(self, owner: type[Case], name: str) -> None:
+        self._name = name
+
+    def __set__(self, instance: object, value: Any) -> None:
+        if self._type is not None:
+            value = self._type(value)
+        instance.__dict__[self._name] = value
+
+    def __get__(self, instance: Case, owner: type[Case]) -> Any:
+        """Retrieve the attribute from the instance dictionary.
+
+        If the value hasn't been set, we attempt to return a default, unless there is no default,
+        in which case we raise an AttributeError.
+
+        """
+        try:
+            return instance.__dict__[self._name]
+        except KeyError:
+            if self._default == _NoDefault:
+                raise AttributeError(
+                    f"'{self._name}' attribute of '{owner.__name__}' class "
+                    "has no default value and must be specified explicitly"
+                )
+            return self._default
+
+
 class PlaningPlateCase(Case):
-    def __init__(self, froude_num: float, angle_of_attack: float):
-        self.froude_num = froude_num
-        self.angle_of_attack = angle_of_attack
+    froude_num = InputAttribute(type=float)
+    angle_of_attack = InputAttribute(type=float)
 
     @property
     def case_dir(self) -> Path:

--- a/examples/planingfsi/run_planingfsi.py
+++ b/examples/planingfsi/run_planingfsi.py
@@ -2,6 +2,7 @@ import dataclasses
 import itertools
 import shutil
 import subprocess
+from functools import cached_property
 from pathlib import Path
 
 import numpy
@@ -27,40 +28,47 @@ class PlaningPlateCase:
         self.froude_num = froude_num
         self.angle_of_attack = angle_of_attack
 
-    def run(self) -> PlaningPlateResults:
-        if not (MIN_FROUDE_NUM <= self.froude_num <= MAX_FROUDE_NUM):
-            raise ValueError(
-                "Input Froude number must be in the range 0.2 <= Fr <= 3.0"
-            )
-
-        case_dir_base = FLAT_PLATE_ROOT / "flat_plate_base"
-
-        case_dir = (
-            FLAT_PLATE_ROOT
-            / f"Fr={self.froude_num:0.1f}_AOA={self.angle_of_attack:0.1f}"
+    @property
+    def case_dir(self) -> Path:
+        """The directory in which to run the case."""
+        return FLAT_PLATE_ROOT / Path(
+            f"Fr={self.froude_num:0.1f}_AOA={self.angle_of_attack:0.1f}"
         )
-        if not case_dir.exists():
-            shutil.copytree(case_dir_base, case_dir)
 
-            with (case_dir / "configDict").open("w") as fp:
-                fp.write("baseDict: './configDict.base'\n")
-                fp.write(f"Fr: {self.froude_num}\n")
-                fp.write(f"AOA: {self.angle_of_attack}\n")
-
-            subprocess.run(["planingfsi", "mesh"], cwd=str(case_dir))
-            subprocess.run(["planingfsi", "run"], cwd=str(case_dir))
-
+    @cached_property
+    def results(self) -> PlaningPlateResults:
+        """Load results from files and return."""
         # Find the latest time directory to load results from
-        results_dir = sorted(
-            case_dir.glob("[0-9]*"), key=lambda d: int(d.name), reverse=True
-        )[0]
+        results_dirs = sorted(
+            self.case_dir.glob("[0-9]*"), key=lambda d: int(d.name), reverse=True
+        )
+        results_dir = results_dirs[0]
         results_dict = load_dict_from_file(results_dir / "forces_total.txt")
-
         return PlaningPlateResults(
             drag=results_dict["Drag"],
             lift=results_dict["Lift"],
             moment=results_dict["Moment"],
         )
+
+    def _execute(self):
+        """Copies base case, sets parameters, and actually runs `planingfsi` for the case."""
+        case_dir_base = FLAT_PLATE_ROOT / "flat_plate_base"
+        shutil.copytree(case_dir_base, self.case_dir)
+        with (self.case_dir / "configDict").open("w") as fp:
+            fp.write("baseDict: './configDict.base'\n")
+            fp.write(f"Fr: {self.froude_num}\n")
+            fp.write(f"AOA: {self.angle_of_attack}\n")
+        subprocess.run(["planingfsi", "mesh"], cwd=str(self.case_dir))
+        subprocess.run(["planingfsi", "run"], cwd=str(self.case_dir))
+
+    def run(self) -> None:
+        if not (MIN_FROUDE_NUM <= self.froude_num <= MAX_FROUDE_NUM):
+            raise ValueError(
+                "Input Froude number must be in the range 0.2 <= Fr <= 3.0"
+            )
+
+        if not self.case_dir.exists():
+            self._execute()
 
 
 def main() -> None:
@@ -71,9 +79,9 @@ def main() -> None:
 
     for froude_num, aoa in itertools.product(froude_nums, AOA_nums):
         case = PlaningPlateCase(froude_num=froude_num, angle_of_attack=aoa)
-        results = case.run()
+        case.run()
 
-        results_dict = dataclasses.asdict(results)
+        results_dict = dataclasses.asdict(case.results)
         results_dict.update({"froude_num": froude_num, "aoa": aoa})
         all_results.append(results_dict)
 

--- a/examples/planingfsi/run_planingfsi.py
+++ b/examples/planingfsi/run_planingfsi.py
@@ -22,54 +22,55 @@ class PlaningPlateResults:
     moment: float
 
 
-def run_planingfsi(froude_num: float, angle_of_attack: float) -> PlaningPlateResults:
-    if not (MIN_FROUDE_NUM <= froude_num <= MAX_FROUDE_NUM):
-        raise ValueError("Input Froude number must be in the range 0.2 <= Fr <= 3.0")
-
-    case_dir_base = FLAT_PLATE_ROOT / "flat_plate_base"
-
-    case_dir = FLAT_PLATE_ROOT / f"Fr={froude_num:0.1f}_AOA={angle_of_attack:0.1f}"
-    if not case_dir.exists():
-        shutil.copytree(case_dir_base, case_dir)
-
-        with (case_dir / "configDict").open("w") as fp:
-            fp.write("baseDict: './configDict.base'\n")
-            fp.write(f"Fr: {froude_num}\n")
-            fp.write(f"AOA: {angle_of_attack}\n")
-
-        subprocess.run(["planingfsi", "mesh"], cwd=str(case_dir))
-        subprocess.run(["planingfsi", "run"], cwd=str(case_dir))
-
-    # Find the latest time directory to load results from
-    results_dir = sorted(
-        case_dir.glob("[0-9]*"), key=lambda d: int(d.name), reverse=True
-    )[0]
-    results_dict = load_dict_from_file(results_dir / "forces_total.txt")
-
-    return PlaningPlateResults(
-        drag=results_dict["Drag"],
-        lift=results_dict["Lift"],
-        moment=results_dict["Moment"],
-    )
-
-
 class PlaningPlateCase:
-    def __init__(self, froude_num: float, aoa: float):
+    def __init__(self, froude_num: float, angle_of_attack: float):
         self.froude_num = froude_num
-        self.aoa = aoa
+        self.angle_of_attack = angle_of_attack
 
     def run(self) -> PlaningPlateResults:
-        return run_planingfsi(self.froude_num, self.aoa)
+        if not (MIN_FROUDE_NUM <= self.froude_num <= MAX_FROUDE_NUM):
+            raise ValueError(
+                "Input Froude number must be in the range 0.2 <= Fr <= 3.0"
+            )
+
+        case_dir_base = FLAT_PLATE_ROOT / "flat_plate_base"
+
+        case_dir = (
+            FLAT_PLATE_ROOT
+            / f"Fr={self.froude_num:0.1f}_AOA={self.angle_of_attack:0.1f}"
+        )
+        if not case_dir.exists():
+            shutil.copytree(case_dir_base, case_dir)
+
+            with (case_dir / "configDict").open("w") as fp:
+                fp.write("baseDict: './configDict.base'\n")
+                fp.write(f"Fr: {self.froude_num}\n")
+                fp.write(f"AOA: {self.angle_of_attack}\n")
+
+            subprocess.run(["planingfsi", "mesh"], cwd=str(case_dir))
+            subprocess.run(["planingfsi", "run"], cwd=str(case_dir))
+
+        # Find the latest time directory to load results from
+        results_dir = sorted(
+            case_dir.glob("[0-9]*"), key=lambda d: int(d.name), reverse=True
+        )[0]
+        results_dict = load_dict_from_file(results_dir / "forces_total.txt")
+
+        return PlaningPlateResults(
+            drag=results_dict["Drag"],
+            lift=results_dict["Lift"],
+            moment=results_dict["Moment"],
+        )
 
 
-if __name__ == "__main__":
+def main() -> None:
     froude_nums = numpy.linspace(0.5, 3.0, 7)
     AOA_nums = numpy.linspace(5.0, 15.0, 5)
 
     all_results = []
 
     for froude_num, aoa in itertools.product(froude_nums, AOA_nums):
-        case = PlaningPlateCase(froude_num, aoa)
+        case = PlaningPlateCase(froude_num=froude_num, angle_of_attack=aoa)
         results = case.run()
 
         results_dict = dataclasses.asdict(results)
@@ -80,3 +81,7 @@ if __name__ == "__main__":
     df.plot.scatter(x="froude_num", y="lift", c="aoa")
 
     pyplot.show()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/planingfsi/run_planingfsi.py
+++ b/examples/planingfsi/run_planingfsi.py
@@ -1,9 +1,12 @@
+import dataclasses
 import shutil
 import subprocess
 from pathlib import Path
 
 import numpy
+import pandas
 from matplotlib import pyplot
+from planingfsi.dictionary import load_dict_from_file
 
 MIN_FROUDE_NUM = 0.2
 MAX_FROUDE_NUM = 3.0
@@ -11,7 +14,14 @@ MAX_FROUDE_NUM = 3.0
 FLAT_PLATE_ROOT = Path(__file__).parent / "flat_plate"
 
 
-def run_flat_plate(froude_num: float, angle_of_attack: float) -> None:
+@dataclasses.dataclass
+class PlaningPlateResults:
+    drag: float
+    lift: float
+    moment: float
+
+
+def run_planingfsi(froude_num: float, angle_of_attack: float) -> PlaningPlateResults:
     if not (MIN_FROUDE_NUM <= froude_num <= MAX_FROUDE_NUM):
         raise ValueError("Input Froude number must be in the range 0.2 <= Fr <= 3.0")
 
@@ -21,27 +31,42 @@ def run_flat_plate(froude_num: float, angle_of_attack: float) -> None:
     if not case_dir.exists():
         shutil.copytree(case_dir_base, case_dir)
 
-    with (case_dir / "configDict").open("w") as fp:
-        fp.write("baseDict: './configDict.base'\n")
-        fp.write(f"Fr: {froude_num}\n")
-        fp.write(f"AOA: {angle_of_attack}\n")
+        with (case_dir / "configDict").open("w") as fp:
+            fp.write("baseDict: './configDict.base'\n")
+            fp.write(f"Fr: {froude_num}\n")
+            fp.write(f"AOA: {angle_of_attack}\n")
 
-    subprocess.run(["planingfsi", "mesh"], cwd=str(case_dir))
-    subprocess.run(["planingfsi", "run"], cwd=str(case_dir))
+        subprocess.run(["planingfsi", "mesh"], cwd=str(case_dir))
+        subprocess.run(["planingfsi", "run"], cwd=str(case_dir))
 
     # Find the latest time directory to load results from
     results_dir = sorted(
         case_dir.glob("[0-9]*"), key=lambda d: int(d.name), reverse=True
     )[0]
+    results_dict = load_dict_from_file(results_dir / "forces_total.txt")
 
-    plate_coords = numpy.loadtxt(results_dir / "coords_plate.txt")
-    fs_coords = numpy.loadtxt(results_dir / "freeSurface.txt")
-
-    pyplot.plot(plate_coords[:, 0], plate_coords[:, 1], "k-")
-    pyplot.plot(fs_coords[:, 0], fs_coords[:, 1], "b-")
-
-    pyplot.show()
+    return PlaningPlateResults(
+        drag=results_dict["Drag"],
+        lift=results_dict["Lift"],
+        moment=results_dict["Moment"],
+    )
 
 
 if __name__ == "__main__":
-    run_flat_plate(froude_num=0.4, angle_of_attack=10.0)
+    froude_nums = numpy.linspace(0.5, 3.0, 7)
+    AOA_nums = numpy.linspace(5.0, 15.0, 5)
+
+    all_results = []
+
+    for froude_num in froude_nums:
+        for aoa in AOA_nums:
+            results = run_planingfsi(froude_num, aoa)
+            results_dict = dataclasses.asdict(results)
+            results_dict.update({"froude_num": froude_num, "aoa": aoa})
+            all_results.append(results_dict)
+
+    df = pandas.DataFrame.from_records(all_results)
+
+    df.plot.scatter(x="froude_num", y="lift", c="aoa")
+
+    pyplot.show()

--- a/examples/planingfsi/run_planingfsi.py
+++ b/examples/planingfsi/run_planingfsi.py
@@ -88,12 +88,14 @@ class InputAttribute:
 
         if self._min_value is not None and value < self._min_value:
             raise ValueError(
-                f"Specified value less than minimum for attribute '{self._name}': ({value} < {self._min_value})"  # noqa: E501
+                "Specified value less than minimum for attribute "
+                f"'{self._name}': ({value} < {self._min_value})"
             )
 
         if self._max_value is not None and value > self._max_value:
             raise ValueError(
-                f"Specified value exceeds maximum for attribute '{self._name}': ({value} > {self._max_value})"  # noqa: E501
+                "Specified value exceeds maximum for attribute "
+                f"'{self._name}': ({value} > {self._max_value})"
             )
 
         instance.__dict__[self._name] = value

--- a/examples/planingfsi/run_planingfsi.py
+++ b/examples/planingfsi/run_planingfsi.py
@@ -175,7 +175,7 @@ class PlaningPlateCase(Case):
         print("Generating mesh")
         subprocess.run(["planingfsi", "mesh"], cwd=str(self.case_dir))
 
-    @step(condition=lambda self: not (self.case_dir / "0").exists())
+    @step(condition=lambda self: not list(self.case_dir.glob("[0-9]*")))
     def _run_planingfsi(self) -> None:
         print("Running planingfsi")
         subprocess.run(["planingfsi", "run"], cwd=str(self.case_dir))
@@ -188,7 +188,7 @@ class PlaningPlateCase(Case):
 
 def main() -> None:
     froude_nums = numpy.arange(0.5, 3.0, 0.25)
-    AOA_nums = numpy.arange(5.0, 15.1, 2.5)
+    AOA_nums = numpy.arange(5.0, 15.1, 1.25)
 
     cases = [
         PlaningPlateCase(froude_num=froude_num, angle_of_attack=aoa)

--- a/examples/planingfsi/run_planingfsi.py
+++ b/examples/planingfsi/run_planingfsi.py
@@ -1,3 +1,9 @@
+"""An example using `lead` to perform a parameter sweep for a single flat planing plate.
+
+Each case is run with `planingfsi` and is characterized by the Froude number
+(flow speed) and angle of attack.
+
+"""
 from __future__ import annotations
 
 import dataclasses
@@ -96,7 +102,7 @@ class PlaningPlateCase(Case):
 
 
 def plot_summary_results(cases: list[PlaningPlateCase]) -> None:
-    """Create a plot of the lift from all of the cases that were run."""
+    """Create a plot of the lift from all the cases that were run."""
     df = pandas.DataFrame.from_records(
         case.results_dict | case.inputs_dict for case in cases
     )
@@ -107,11 +113,11 @@ def plot_summary_results(cases: list[PlaningPlateCase]) -> None:
 def main() -> None:
     # Generate a list of cases
     froude_nums = numpy.arange(0.5, 3.0, 0.25)
-    AOA_nums = numpy.arange(5.0, 15.1, 1.25)
+    angles_of_attack = numpy.arange(5.0, 15.1, 1.25)
 
     cases = [
         PlaningPlateCase(froude_num=froude_num, angle_of_attack=aoa)
-        for froude_num, aoa in itertools.product(froude_nums, AOA_nums)
+        for froude_num, aoa in itertools.product(froude_nums, angles_of_attack)
     ]
 
     # Run the cases

--- a/examples/planingfsi/run_planingfsi.py
+++ b/examples/planingfsi/run_planingfsi.py
@@ -1,0 +1,47 @@
+import shutil
+import subprocess
+from pathlib import Path
+
+import numpy
+from matplotlib import pyplot
+
+MIN_FROUDE_NUM = 0.2
+MAX_FROUDE_NUM = 3.0
+
+FLAT_PLATE_ROOT = Path(__file__).parent / "flat_plate"
+
+
+def run_flat_plate(froude_num: float, angle_of_attack: float) -> None:
+    if not (MIN_FROUDE_NUM <= froude_num <= MAX_FROUDE_NUM):
+        raise ValueError("Input Froude number must be in the range 0.2 <= Fr <= 3.0")
+
+    case_dir_base = FLAT_PLATE_ROOT / "flat_plate_base"
+
+    case_dir = FLAT_PLATE_ROOT / f"Fr={froude_num:0.1f}_AOA={angle_of_attack:0.1f}"
+    if not case_dir.exists():
+        shutil.copytree(case_dir_base, case_dir)
+
+    with (case_dir / "configDict").open("w") as fp:
+        fp.write("baseDict: './configDict.base'\n")
+        fp.write(f"Fr: {froude_num}\n")
+        fp.write(f"AOA: {angle_of_attack}\n")
+
+    subprocess.run(["planingfsi", "mesh"], cwd=str(case_dir))
+    subprocess.run(["planingfsi", "run"], cwd=str(case_dir))
+
+    # Find the latest time directory to load results from
+    results_dir = sorted(
+        case_dir.glob("[0-9]*"), key=lambda d: int(d.name), reverse=True
+    )[0]
+
+    plate_coords = numpy.loadtxt(results_dir / "coords_plate.txt")
+    fs_coords = numpy.loadtxt(results_dir / "freeSurface.txt")
+
+    pyplot.plot(plate_coords[:, 0], plate_coords[:, 1], "k-")
+    pyplot.plot(fs_coords[:, 0], fs_coords[:, 1], "b-")
+
+    pyplot.show()
+
+
+if __name__ == "__main__":
+    run_flat_plate(froude_num=0.4, angle_of_attack=10.0)

--- a/examples/planingfsi/run_planingfsi.py
+++ b/examples/planingfsi/run_planingfsi.py
@@ -1,11 +1,9 @@
 from __future__ import annotations
 
 import dataclasses
-import functools
 import itertools
 import shutil
 import subprocess
-from collections.abc import Callable
 from functools import cached_property
 from pathlib import Path
 from typing import Any
@@ -15,6 +13,10 @@ import pandas
 from matplotlib import pyplot
 from planingfsi.dictionary import load_dict_from_file
 
+from lead import Case
+from lead import InputAttribute
+from lead import step
+
 FLAT_PLATE_ROOT = Path(__file__).parent / "flat_plate"
 
 
@@ -23,99 +25,6 @@ class PlaningPlateResults:
     drag: float
     lift: float
     moment: float
-
-
-class Case:
-    """Base case for all cases."""
-
-    def __init__(self, **kwargs: Any):
-        for name, value in kwargs.items():
-            setattr(self, name, value)
-
-
-def step(condition: Callable[[Any], bool]) -> Any:
-    def decorator(f: Callable[[Case], None]) -> Callable[[Case], None]:
-        @functools.wraps(f)
-        def new_f(self: Case) -> None:
-            if condition(self):
-                return f(self)
-            else:
-                return None
-
-        return new_f
-
-    return decorator
-
-
-class _NoDefault:
-    """Used as a sentinel to indicate lack of a default value for an `InputAttribute`."""
-
-
-_builtin_type = type
-
-
-class InputAttribute:
-    _name: str
-    _type: type | None
-    _min_value: float | None
-    _max_value: float | None
-
-    def __init__(
-        self,
-        *,
-        type: type | None = None,
-        default: Any = _NoDefault,
-        min: float | None = None,
-        max: float | None = None,
-    ):
-        if type is not None:
-            self._type = type
-        elif default != _NoDefault:
-            self._type = _builtin_type(default)
-        else:
-            self._type = None
-
-        self._default = default
-        self._min_value = min
-        self._max_value = max
-
-    def __set_name__(self, owner: type[Case], name: str) -> None:
-        self._name = name
-
-    def __set__(self, instance: object, value: Any) -> None:
-        if self._type is not None:
-            value = self._type(value)
-
-        if self._min_value is not None and value < self._min_value:
-            raise ValueError(
-                "Specified value less than minimum for attribute "
-                f"'{self._name}': ({value} < {self._min_value})"
-            )
-
-        if self._max_value is not None and value > self._max_value:
-            raise ValueError(
-                "Specified value exceeds maximum for attribute "
-                f"'{self._name}': ({value} > {self._max_value})"
-            )
-
-        instance.__dict__[self._name] = value
-
-    def __get__(self, instance: Case, owner: type[Case]) -> Any:
-        """Retrieve the attribute from the instance dictionary.
-
-        If the value hasn't been set, we attempt to return a default, unless there is no default,
-        in which case we raise an AttributeError.
-
-        """
-        try:
-            return instance.__dict__[self._name]
-        except KeyError:
-            if self._default == _NoDefault:
-                raise AttributeError(
-                    f"'{self._name}' attribute of '{owner.__name__}' class "
-                    "has no default value and must be specified explicitly"
-                )
-            return self._default
 
 
 class PlaningPlateCase(Case):

--- a/examples/planingfsi/run_planingfsi.py
+++ b/examples/planingfsi/run_planingfsi.py
@@ -104,8 +104,10 @@ class PlaningPlateCase(Case):
     @property
     def case_dir(self) -> Path:
         """The directory in which to run the case."""
-        return FLAT_PLATE_ROOT / Path(
-            f"Fr={self.froude_num:0.1f}_AOA={self.angle_of_attack:0.1f}"
+        return Path(
+            FLAT_PLATE_ROOT,
+            "cases",
+            f"Fr={self.froude_num:0.2f}_AOA={self.angle_of_attack:0.2f}",
         )
 
     @cached_property

--- a/examples/planingfsi/run_planingfsi.py
+++ b/examples/planingfsi/run_planingfsi.py
@@ -55,8 +55,8 @@ _builtin_type = type
 
 
 class InputAttribute:
-    _type: type | None
     _name: str
+    _type: type | None
     _min_value: float | None
     _max_value: float | None
 

--- a/examples/planingfsi/run_planingfsi.py
+++ b/examples/planingfsi/run_planingfsi.py
@@ -95,7 +95,17 @@ class PlaningPlateCase(Case):
         self._run_planingfsi()
 
 
+def plot_summary_results(cases: list[PlaningPlateCase]) -> None:
+    """Create a plot of the lift from all of the cases that were run."""
+    df = pandas.DataFrame.from_records(
+        case.results_dict | case.inputs_dict for case in cases
+    )
+    df.plot.scatter(x="froude_num", y="lift", c="angle_of_attack", cmap="inferno")
+    pyplot.show()
+
+
 def main() -> None:
+    # Generate a list of cases
     froude_nums = numpy.arange(0.5, 3.0, 0.25)
     AOA_nums = numpy.arange(5.0, 15.1, 1.25)
 
@@ -104,15 +114,12 @@ def main() -> None:
         for froude_num, aoa in itertools.product(froude_nums, AOA_nums)
     ]
 
+    # Run the cases
     for case in cases:
         case.run()
 
-    df = pandas.DataFrame.from_records(
-        case.results_dict | case.inputs_dict for case in cases
-    )
-    df.plot.scatter(x="froude_num", y="lift", c="angle_of_attack", cmap="inferno")
-
-    pyplot.show()
+    # Post-process the cases
+    plot_summary_results(cases)
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,9 @@ authors = [
     "Jose Mesa <jmesa@anaconda.com>",
 ]
 license = "MIT"
+packages = [
+    { include = "lead", from = "src" },
+]
 
 [tool.poetry.dependencies]
 python = ">=3.9,<3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ planingfsi = { git = "https://github.com/mattkram/planingfsi.git", branch = "dev
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1.2"
+pytest-cov = "^3.0.0"
 
 [tool.poetry.extras]
 examples = ["planingfsi", "pandas"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,12 +12,13 @@ license = "MIT"
 python = ">=3.9,<3.11"
 
 # Optional dependencies for examples
+pandas = { version = "^1.4.3", optional = true }
 planingfsi = { git = "https://github.com/mattkram/planingfsi.git", branch = "dev", optional = true }
 
 [tool.poetry.dev-dependencies]
 
 [tool.poetry.extras]
-examples = ["planingfsi"]
+examples = ["planingfsi", "pandas"]
 
 [tool.isort]
 profile = "black"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ pandas = { version = "^1.4.3", optional = true }
 planingfsi = { git = "https://github.com/mattkram/planingfsi.git", branch = "dev", optional = true }
 
 [tool.poetry.dev-dependencies]
+pytest = "^7.1.2"
 
 [tool.poetry.extras]
 examples = ["planingfsi", "pandas"]

--- a/src/lead/__init__.py
+++ b/src/lead/__init__.py
@@ -1,5 +1,5 @@
 from lead.core import Case
-from lead.core import InputAttribute
+from lead.core import InputParameter
 from lead.core import step
 
-__all__ = ["Case", "step", "InputAttribute"]
+__all__ = ["Case", "InputParameter", "step"]

--- a/src/lead/__init__.py
+++ b/src/lead/__init__.py
@@ -1,0 +1,5 @@
+from lead.core import Case
+from lead.core import InputAttribute
+from lead.core import step
+
+__all__ = ["Case", "step", "InputAttribute"]

--- a/src/lead/core.py
+++ b/src/lead/core.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import functools
+from collections.abc import Callable
+from typing import Any
+
+
+class Case:
+    """Base case for all cases."""
+
+    def __init__(self, **kwargs: Any):
+        for name, value in kwargs.items():
+            setattr(self, name, value)
+
+
+def step(condition: Callable[[Any], bool]) -> Any:
+    def decorator(f: Callable[[Case], None]) -> Callable[[Case], None]:
+        @functools.wraps(f)
+        def new_f(self: Case) -> None:
+            if condition(self):
+                return f(self)
+            else:
+                return None
+
+        return new_f
+
+    return decorator
+
+
+class _NoDefault:
+    """Used as a sentinel to indicate lack of a default value for an `InputAttribute`."""
+
+
+_builtin_type = type
+
+
+class InputAttribute:
+    _name: str
+    _type: type | None
+    _min_value: float | None
+    _max_value: float | None
+
+    def __init__(
+        self,
+        *,
+        type: type | None = None,
+        default: Any = _NoDefault,
+        min: float | None = None,
+        max: float | None = None,
+    ):
+        if type is not None:
+            self._type = type
+        elif default != _NoDefault:
+            self._type = _builtin_type(default)
+        else:
+            self._type = None
+
+        self._default = default
+        self._min_value = min
+        self._max_value = max
+
+    def __set_name__(self, owner: type[Case], name: str) -> None:
+        self._name = name
+
+    def __set__(self, instance: object, value: Any) -> None:
+        if self._type is not None:
+            value = self._type(value)
+
+        if self._min_value is not None and value < self._min_value:
+            raise ValueError(
+                "Specified value less than minimum for attribute "
+                f"'{self._name}': ({value} < {self._min_value})"
+            )
+
+        if self._max_value is not None and value > self._max_value:
+            raise ValueError(
+                "Specified value exceeds maximum for attribute "
+                f"'{self._name}': ({value} > {self._max_value})"
+            )
+
+        instance.__dict__[self._name] = value
+
+    def __get__(self, instance: Case, owner: type[Case]) -> Any:
+        """Retrieve the attribute from the instance dictionary.
+
+        If the value hasn't been set, we attempt to return a default, unless there is no default,
+        in which case we raise an AttributeError.
+
+        """
+        try:
+            return instance.__dict__[self._name]
+        except KeyError:
+            if self._default == _NoDefault:
+                raise AttributeError(
+                    f"'{self._name}' attribute of '{owner.__name__}' class "
+                    "has no default value and must be specified explicitly"
+                )
+            return self._default

--- a/src/lead/core.py
+++ b/src/lead/core.py
@@ -31,6 +31,8 @@ class InputParameter:
         elif default != _NoDefault:
             self._type = _builtin_type(default)
         else:
+            # TODO: Consider making this an exception instead.
+            #       The type should either be explicitly provided or inferred from default.
             self._type = None
 
         self._default = default

--- a/src/lead/core.py
+++ b/src/lead/core.py
@@ -5,28 +5,6 @@ from collections.abc import Callable
 from typing import Any
 
 
-class Case:
-    """Base case for all cases."""
-
-    def __init__(self, **kwargs: Any):
-        for name, value in kwargs.items():
-            setattr(self, name, value)
-
-
-def step(condition: Callable[[Any], bool]) -> Any:
-    def decorator(f: Callable[[Case], None]) -> Callable[[Case], None]:
-        @functools.wraps(f)
-        def new_f(self: Case) -> None:
-            if condition(self):
-                return f(self)
-            else:
-                return None
-
-        return new_f
-
-    return decorator
-
-
 class _NoDefault:
     """Used as a sentinel to indicate lack of a default value for an `InputAttribute`."""
 
@@ -96,3 +74,25 @@ class InputParameter:
                     "has no default value and must be specified explicitly"
                 )
             return self._default
+
+
+def step(condition: Callable[[Any], bool]) -> Any:
+    def decorator(f: Callable[[Case], None]) -> Callable[[Case], None]:
+        @functools.wraps(f)
+        def new_f(self: Case) -> None:
+            if condition(self):
+                return f(self)
+            else:
+                return None
+
+        return new_f
+
+    return decorator
+
+
+class Case:
+    """Base case for all cases."""
+
+    def __init__(self, **kwargs: Any):
+        for name, value in kwargs.items():
+            setattr(self, name, value)

--- a/src/lead/core.py
+++ b/src/lead/core.py
@@ -31,9 +31,9 @@ class InputParameter:
         elif default != _NoDefault:
             self._type = _builtin_type(default)
         else:
-            # TODO: Consider making this an exception instead.
-            #       The type should either be explicitly provided or inferred from default.
-            self._type = None
+            raise TypeError(
+                "An 'InputParameter' must either explicitly set the type, or have a default value to infer it from."
+            )
 
         self._default = default
         self._min_value = min
@@ -82,7 +82,7 @@ class InputParameter:
 #       in the decorator definition for condition
 
 
-def step(condition: Callable[[Case], bool] | None = None) -> Any:  # type: ignore
+def step(condition: Callable[[Any], bool] | None = None) -> Any:
     """A decorator to define steps to be performed when running a `Case`.
 
     The step should not return a value.

--- a/src/lead/core.py
+++ b/src/lead/core.py
@@ -76,11 +76,30 @@ class InputParameter:
             return self._default
 
 
-def step(condition: Callable[[Any], bool]) -> Any:
+def step(condition: Callable[[Case], bool] | None = None) -> Any:
+    """A decorator to define steps to be performed when running a `Case`.
+
+    The step should not return a value.
+
+    Args:
+        condition: an optional callable which can be used to determine whether the step should run.
+            It will receive the `Case` instance as its only argument, and must return a boolean
+            which, if True, the step will run. Otherwise, it will be skipped.
+
+    Usage:
+        ```
+        class MyCase(Case):
+            @step(condition=lambda case: case.case_dir.exists())
+            def some_analysis_step(self):
+                # do something
+        ```
+
+    """
+
     def decorator(f: Callable[[Case], None]) -> Callable[[Case], None]:
         @functools.wraps(f)
         def new_f(self: Case) -> None:
-            if condition(self):
+            if condition is not None and condition(self):
                 return f(self)
             else:
                 return None

--- a/src/lead/core.py
+++ b/src/lead/core.py
@@ -78,7 +78,11 @@ class InputParameter:
             return self._default
 
 
-def step(condition: Callable[[Case], bool] | None = None) -> Any:
+# TODO: I can't figure out how to properly resolve type errors when the argument is `Case`
+#       in the decorator definition for condition
+
+
+def step(condition: Callable[[Case], bool] | None = None) -> Any:  # type: ignore
     """A decorator to define steps to be performed when running a `Case`.
 
     The step should not return a value.

--- a/src/lead/core.py
+++ b/src/lead/core.py
@@ -34,7 +34,7 @@ class _NoDefault:
 _builtin_type = type
 
 
-class InputAttribute:
+class InputParameter:
     _name: str
     _type: type | None
     _min_value: float | None

--- a/tests/test_case_handler.py
+++ b/tests/test_case_handler.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from lead import Case
+from lead import InputParameter
+
+
+class MyCase(Case):
+    my_param = InputParameter(type=float, min=2.0, max=5.0)
+
+
+@pytest.fixture()
+def case() -> MyCase:
+    return MyCase(my_param=3.0)
+
+
+@pytest.mark.parametrize("input_value", [3.0, 3, "3", "3.0"])
+def test_case_handler_parameter_type_conversion(case: MyCase, input_value: Any) -> None:
+    """The value is coerced to the proper type."""
+    assert case.my_param == pytest.approx(3.0)
+
+
+@pytest.mark.parametrize("input_value", [1.0, 6.0])
+def test_case_handler_parameter_bounds_raises_exception(
+    case: MyCase, input_value: float
+) -> None:
+    """An exception is raised when attempting to set the value out of bounds."""
+    with pytest.raises(ValueError):
+        case.my_param = input_value

--- a/tests/test_case_handler.py
+++ b/tests/test_case_handler.py
@@ -35,13 +35,13 @@ def test_case_parameter_required_raises_exception(case: MyCase) -> None:
 
 
 @pytest.mark.parametrize("input_value", [3.0, 3, "3", "3.0"])
-def test_case_handler_parameter_type_conversion(case: MyCase, input_value: Any) -> None:
+def test_case_parameter_type_conversion(case: MyCase, input_value: Any) -> None:
     """The value is coerced to the proper type."""
     assert case.my_param == pytest.approx(3.0)
 
 
 @pytest.mark.parametrize("input_value", [1.0, 6.0])
-def test_case_handler_parameter_bounds_raises_exception(
+def test_case_parameter_bounds_raises_exception(
     case: MyCase, input_value: float
 ) -> None:
     """An exception is raised when attempting to set the value out of bounds."""

--- a/tests/test_case_handler.py
+++ b/tests/test_case_handler.py
@@ -12,7 +12,7 @@ from lead import step
 class MyCase(Case):
     my_param = InputParameter(type=float, min=2.0, max=5.0)
     param_with_default = InputParameter(default=10.0)
-    required_param = InputParameter()
+    required_param = InputParameter(type=float)
 
     @step(condition=lambda self: self.my_param > 4)
     def change_param_with_default(self) -> None:
@@ -32,6 +32,11 @@ def test_case_parameter_required_raises_exception(case: MyCase) -> None:
     """A parameter with no default that is not set raises an exception when accessed."""
     with pytest.raises(AttributeError):
         _ = case.required_param
+
+
+def test_case_parameter_type_required() -> None:
+    with pytest.raises(TypeError):
+        InputParameter()
 
 
 @pytest.mark.parametrize("input_value", [3.0, 3, "3", "3.0"])

--- a/tests/test_case_handler.py
+++ b/tests/test_case_handler.py
@@ -10,11 +10,23 @@ from lead import InputParameter
 
 class MyCase(Case):
     my_param = InputParameter(type=float, min=2.0, max=5.0)
+    param_with_default = InputParameter(default=10.0)
+    required_param = InputParameter()
 
 
 @pytest.fixture()
 def case() -> MyCase:
     return MyCase(my_param=3.0)
+
+
+def test_case_parameter_default(case: MyCase) -> None:
+    assert case.param_with_default == pytest.approx(10.0)
+
+
+def test_case_parameter_required_raises_exception(case: MyCase) -> None:
+    """A parameter with no default that is not set raises an exception when accessed."""
+    with pytest.raises(AttributeError):
+        _ = case.required_param
 
 
 @pytest.mark.parametrize("input_value", [3.0, 3, "3", "3.0"])


### PR DESCRIPTION
This PR adds an example of a flat planing plate as a way to develop the first case handler using the `planingfsi` library. The preliminary `Case` API is defined, as well as the `@step` decorator and `InputParameter` descriptor class.